### PR TITLE
Flipped Guidelines

### DIFF
--- a/Eyeliner.roboFontExt/info.plist
+++ b/Eyeliner.roboFontExt/info.plist
@@ -23,6 +23,6 @@
 	<key>timeStamp</key>
 	<real>1579890909.1397052</real>
 	<key>version</key>
-	<string>1.2.5</string>
+	<string>1.2.6</string>
 </dict>
 </plist>

--- a/Eyeliner.roboFontExt/lib/Eyeliner.py
+++ b/Eyeliner.roboFontExt/lib/Eyeliner.py
@@ -78,9 +78,9 @@ class Eyeliner():
         f_guide_xs = {}
         f_guide_ys = {}
         for guideline in self.f.guidelines:
-            if guideline.angle == 0:
+            if guideline.angle in [0,180]:
                 f_guide_ys[otRound(guideline.y)] = guideline.color
-            elif guideline.angle == 90:
+            elif guideline.angle in [90, 270]:
                 f_guide_xs[otRound(guideline.x)] = guideline.color
         # get blue y's and whether they're set to be displayed
         blue_vals  = self.f.info.postscriptBlueValues + self.f.info.postscriptOtherBlues


### PR DESCRIPTION
Eyeliner misses guides that have an angle of 180 or 270 despite being the same as 0 and 90.